### PR TITLE
Fix/timezone-moving-average-and-difference

### DIFF
--- a/Flask-API/main.py
+++ b/Flask-API/main.py
@@ -1017,8 +1017,6 @@ def get_euclidean_distance():
     filename1 = request.args.get("filename1")
     filename2 = request.args.get("filename2")
     category = request.args.get("category")
-    start = request.args.get("start")
-    end = request.args.get("end")
     tolerance = request.args.get("tolerance")
 
     try:

--- a/Flask-API/main.py
+++ b/Flask-API/main.py
@@ -89,7 +89,12 @@ def _apply_timezone_conversion(data, param_name="data"):
     )
 
     try:
-        return convert_timeseries_keys_timezone(data, tz_str=tz_param, keep_offset=keep_offset_param)
+        return convert_timeseries_keys_timezone(
+            data,
+            tz_str=tz_param,
+            keep_offset=keep_offset_param,
+        )
+
     except Exception as e:
         logger.warning(
             "Time conversion failed for %s: %s. Returning original timestamps.",
@@ -111,7 +116,13 @@ def health_check():
 
 @app.route("/", methods=["GET"])
 def index():
-    return _create_response({"status": "API is working", "service": "SeriesDiff Backend"}, 200)
+    return _create_response(
+        {
+            "status": "API is working",
+            "service": "SeriesDiff Backend",
+        },
+        200,
+    )
 
 
 @app.route("/api/timeseries", methods=["GET"])
@@ -196,10 +207,18 @@ def transform_pivot():
     values_col = request.form.get("values_col")
 
     if not all([index_col, columns_col, values_col]):
-        return _create_response({"error": "Please select columns for Index, Category and Value."}, 400)
+        return _create_response(
+            {"error": "Please select columns for Index, Category and Value."},
+            400,
+        )
 
     try:
-        result_data = pivot_file(file, index_col, columns_col, values_col)
+        result_data = pivot_file(
+            file,
+            index_col,
+            columns_col,
+            values_col,
+        )
 
         return _create_response(result_data, 200)
 
@@ -221,11 +240,18 @@ def get_scatter_data():
 
     try:
         # Pobranie danych
-        data1 = timeseries_manager.get_timeseries(token=token, filename=filename1, category=category)
+        data1 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename1,
+            category=category,
+        )
         data1 = _apply_timezone_conversion(data1, "data1")
         serie1 = metric_service.extract_series_from_dict(data1, category, filename1)
-
-        data2 = timeseries_manager.get_timeseries(token=token, filename=filename2, category=category)
+        data2 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename2,
+            category=category,
+        )
         data2 = _apply_timezone_conversion(data2, "data2")
         serie2 = metric_service.extract_series_from_dict(data2, category, filename2)
 
@@ -236,7 +262,13 @@ def get_scatter_data():
         # Format: [{x: 10, y: 12, time: "2023-01-01..."}, ...]
         result = []
         for index, row in df_merged.iterrows():
-            result.append({"x": row["value1"], "y": row["value2"], "time": index.isoformat()})
+            result.append(
+                {
+                    "x": row["value1"],
+                    "y": row["value2"],
+                    "time": index.isoformat(),
+                }
+            )
 
         return _create_response(result, 200)
 
@@ -259,7 +291,13 @@ def get_mean():
     start = request.args.get("start")
     end = request.args.get("end")
     try:
-        data = timeseries_manager.get_timeseries(token=token, filename=filename, category=category, start=start, end=end)
+        data = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie = metric_service.extract_series_from_dict(data, category, filename)
         mean = metric_service.calculate_basic_statistics(serie)["mean"]
     except (KeyError, ValueError) as e:
@@ -307,7 +345,13 @@ def get_median():
     start = request.args.get("start")
     end = request.args.get("end")
     try:
-        data = timeseries_manager.get_timeseries(token=token, filename=filename, category=category, start=start, end=end)
+        data = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie = metric_service.extract_series_from_dict(data, category, filename)
         median = metric_service.calculate_basic_statistics(serie)["median"]
         logger.debug(
@@ -363,7 +407,13 @@ def get_variance():
     start = request.args.get("start")
     end = request.args.get("end")
     try:
-        data = timeseries_manager.get_timeseries(token=token, filename=filename, category=category, start=start, end=end)
+        data = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie = metric_service.extract_series_from_dict(data, category, filename)
         variance = metric_service.calculate_basic_statistics(serie)["variance"]
     except (KeyError, ValueError) as e:
@@ -410,7 +460,13 @@ def get_standard_deviation():
     start = request.args.get("start")
     end = request.args.get("end")
     try:
-        data = timeseries_manager.get_timeseries(token=token, filename=filename, category=category, start=start, end=end)
+        data = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie = metric_service.extract_series_from_dict(data, category, filename)
         std_dev = metric_service.calculate_basic_statistics(serie)["std_dev"]
     except (KeyError, ValueError) as e:
@@ -453,7 +509,9 @@ def get_autocorrelation():
     if not request.args.get("filename") or not request.args.get("category"):
         logger.error("Missing required parameters: 'filename' and 'category'")
         return (
-            jsonify({"error": "Missing required parameters: 'filename' and 'category'"}),
+            jsonify(
+                {"error": "Missing required parameters: 'filename' and 'category'"}
+            ),
             400,
         )
     token, _ = _get_session_token()
@@ -462,7 +520,13 @@ def get_autocorrelation():
     start = request.args.get("start")
     end = request.args.get("end")
     try:
-        data = timeseries_manager.get_timeseries(token=token, filename=filename, category=category, start=start, end=end)
+        data = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie = metric_service.extract_series_from_dict(data, category, filename)
         acf_value = metric_service.calculate_autocorrelation(serie)
     except (KeyError, ValueError) as e:
@@ -509,7 +573,13 @@ def get_coefficient_of_variation():
     start = request.args.get("start")
     end = request.args.get("end")
     try:
-        data = timeseries_manager.get_timeseries(token=token, filename=filename, category=category, start=start, end=end)
+        data = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie = metric_service.extract_series_from_dict(data, category, filename)
         cv = metric_service.calculate_coefficient_of_variation(serie)
     except (KeyError, ValueError) as e:
@@ -556,7 +626,13 @@ def get_iqr():
     start = request.args.get("start")
     end = request.args.get("end")
     try:
-        data = timeseries_manager.get_timeseries(token=token, filename=filename, category=category, start=start, end=end)
+        data = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie = metric_service.extract_series_from_dict(data, category, filename)
         iqr = metric_service.calculate_iqr(serie)
     except (KeyError, ValueError) as e:
@@ -605,11 +681,25 @@ def get_pearson_correlation():
     end = request.args.get("end")
     tolerance = request.args.get("tolerance")
     try:
-        data1 = timeseries_manager.get_timeseries(token=token, filename=filename1, category=category, start=start, end=end)
+        data1 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename1,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie1 = metric_service.extract_series_from_dict(data1, category, filename1)
-        data2 = timeseries_manager.get_timeseries(token=token, filename=filename2, category=category, start=start, end=end)
+        data2 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename2,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie2 = metric_service.extract_series_from_dict(data2, category, filename2)
-        correlation = metric_service.calculate_pearson_correlation(serie1, serie2, tolerance)
+        correlation = metric_service.calculate_pearson_correlation(
+            serie1, serie2, tolerance
+        )
     except (KeyError, ValueError) as e:
         logger.error(
             "Error calculating Pearson correlation for filenames '%s' and '%s' in category '%s': %s",
@@ -654,14 +744,28 @@ def get_cosine_similarity():
 
     try:
         # Pobierz dane dla obu plików
-        data1 = timeseries_manager.get_timeseries(token=token, filename=filename1, category=category, start=start, end=end)
+        data1 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename1,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie1 = metric_service.extract_series_from_dict(data1, category, filename1)
 
-        data2 = timeseries_manager.get_timeseries(token=token, filename=filename2, category=category, start=start, end=end)
+        data2 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename2,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie2 = metric_service.extract_series_from_dict(data2, category, filename2)
 
         # Oblicz cosine similarity
-        similarity = metric_service.calculate_cosine_similarity(serie1, serie2, tolerance)
+        similarity = metric_service.calculate_cosine_similarity(
+            serie1, serie2, tolerance
+        )
 
     except (KeyError, ValueError) as e:
         logger.error(
@@ -708,10 +812,22 @@ def get_mae():
     tolerance = request.args.get("tolerance")
 
     try:
-        data1 = timeseries_manager.get_timeseries(token=token, filename=filename1, category=category, start=start, end=end)
+        data1 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename1,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie1 = metric_service.extract_series_from_dict(data1, category, filename1)
 
-        data2 = timeseries_manager.get_timeseries(token=token, filename=filename2, category=category, start=start, end=end)
+        data2 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename2,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie2 = metric_service.extract_series_from_dict(data2, category, filename2)
 
         mae = metric_service.calculate_mae(serie1, serie2, tolerance)
@@ -753,10 +869,22 @@ def get_rmse():
     tolerance = request.args.get("tolerance")
 
     try:
-        data1 = timeseries_manager.get_timeseries(token=token, filename=filename1, category=category, start=start, end=end)
+        data1 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename1,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie1 = metric_service.extract_series_from_dict(data1, category, filename1)
 
-        data2 = timeseries_manager.get_timeseries(token=token, filename=filename2, category=category, start=start, end=end)
+        data2 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename2,
+            category=category,
+            start=start,
+            end=end,
+        )
         serie2 = metric_service.extract_series_from_dict(data2, category, filename2)
 
         rmse = metric_service.calculate_rmse(serie1, serie2, tolerance)
@@ -793,13 +921,23 @@ def get_difference():
     tolerance = request.args.get("tolerance")
 
     try:
-        data1 = timeseries_manager.get_timeseries(token=token, filename=filename1, category=category)
+        data1 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename1,
+            category=category,
+        )
         serie1 = metric_service.extract_series_from_dict(data1, category, filename1)
 
-        data2 = timeseries_manager.get_timeseries(token=token, filename=filename2, category=category)
+        data2 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename2,
+            category=category,
+        )
         serie2 = metric_service.extract_series_from_dict(data2, category, filename2)
 
-        difference_series = metric_service.calculate_difference(serie1, serie2, tolerance)
+        difference_series = metric_service.calculate_difference(
+            serie1, serie2, tolerance
+        )
 
     except Exception as e:
         return _create_response({"error": str(e)}, 400)
@@ -816,15 +954,25 @@ def get_rolling_mean():
     window_size = request.args.get("window_size", "1d")
 
     try:
-        data = timeseries_manager.get_timeseries(token=token, filename=filename, category=category)
+        data = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename,
+            category=category,
+        )
         serie = metric_service.extract_series_from_dict(data, category, filename)
 
-        rolling_mean_series = metric_service.calculate_rolling_mean(serie, window_size)
+        rolling_mean_series = metric_service.calculate_rolling_mean(
+            serie,
+            window_size,
+        )
 
     except Exception as e:
         return _create_response({"error": str(e)}, 400)
 
-    rolling_mean_series = _apply_timezone_conversion(rolling_mean_series, "rolling_mean")
+    rolling_mean_series = _apply_timezone_conversion(
+        rolling_mean_series,
+        "rolling_mean",
+    )
     return _create_response({"rolling_mean": rolling_mean_series}, 200)
 
 
@@ -838,9 +986,21 @@ def get_dtw():
     end = request.args.get("end")
 
     try:
-        data1 = timeseries_manager.get_timeseries(token=token, filename=filename1, category=category, start=start, end=end)
+        data1 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename1,
+            category=category,
+            start=start,
+            end=end,
+        )
         series1 = metric_service.extract_series_from_dict(data1, category, filename1)
-        data2 = timeseries_manager.get_timeseries(token=token, filename=filename2, category=category, start=start, end=end)
+        data2 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename2,
+            category=category,
+            start=start,
+            end=end,
+        )
         series2 = metric_service.extract_series_from_dict(data2, category, filename2)
 
         dtw_distance = metric_service.calculate_dtw(series1, series2)
@@ -860,13 +1020,25 @@ def get_euclidean_distance():
     tolerance = request.args.get("tolerance")
 
     try:
-        data1 = timeseries_manager.get_timeseries(token=token, filename=filename1, category=category)
+        data1 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename1,
+            category=category,
+        )
         series1 = metric_service.extract_series_from_dict(data1, category, filename1)
 
-        data2 = timeseries_manager.get_timeseries(token=token, filename=filename2, category=category)
+        data2 = timeseries_manager.get_timeseries(
+            token=token,
+            filename=filename2,
+            category=category,
+        )
         series2 = metric_service.extract_series_from_dict(data2, category, filename2)
 
-        euclidean_distances = metric_service.calculate_euclidean_distance(series1, series2, tolerance)
+        euclidean_distances = metric_service.calculate_euclidean_distance(
+            series1,
+            series2,
+            tolerance,
+        )
 
     except Exception as e:
         return _create_response({"error": str(e)}, 400)
@@ -885,22 +1057,34 @@ def add_timeseries():
     token, _ = _get_session_token()
     data = request.get_json()
     if not isinstance(data, dict):
-        logger.error("Invalid data format: Expected a JSON object with keys as identifiers")
-        return _create_response({"error": "Expected a JSON object with keys as identifiers"}, 400)
+        logger.error(
+            "Invalid data format: Expected a JSON object with keys as identifiers"
+        )
+        return _create_response(
+            {"error": "Expected a JSON object with keys as identifiers"},
+            400,
+        )
     try:
         current_timeseries = timeseries_manager.get_timeseries(token=token)
         for time, values in data.items():
             if not isinstance(values, dict):
-                logger.error("Invalid data format for time '%s': Expected a dictionary", time)
+                logger.error(
+                    "Invalid data format for time '%s': Expected a dictionary",
+                    time,
+                )
                 return _create_response(
-                    {"error": f"Invalid data format for time '{time}': Expected a dictionary"},
+                    {
+                        "error": f"Invalid data format for time '{time}': Expected a dictionary"
+                    },
                     400,
                 )
             timeseries_manager.add_timeseries(token, time, values)
             current_timeseries[time] = values
     except ValueError as e:
         logger.error("Error adding timeseries for time '%s': %s", time, e)
-        timeseries_manager.sessions[token] = current_timeseries  # Restore previous state
+        timeseries_manager.sessions[token] = (
+            current_timeseries  # Restore previous state
+        )
         return _create_response({"error": str(e)}, 400)
     logger.info("All timeseries data uploaded successfully")
     return _create_response({"status": "Data uploaded"}, 201)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes timezone handling and applies it consistently across endpoints.
> 
> - Adds `_apply_timezone_conversion` to wrap `convert_timeseries_keys_timezone` with request params and logging
> - Applies timezone conversion to `GET /api/timeseries` results, inputs for `scatter_data`, and outputs of `difference` and `rolling_mean`
> - Removes `start`/`end` parameters from `GET /api/timeseries/euclidean_distance` and stops passing them to data retrieval
> - Minor refactors: consistent param passing and response formatting in several routes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2649612f877b9e2d3a9bd28f306a764b762eed63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->